### PR TITLE
Add polling mode and a few small improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,5 @@
 name: Build and package
-on:
-  push:
-    branches: [main, go-rewrite]
-    tags:
-      - "v*"
+on: push
 jobs:
   build:
     name: SkillerWhaleSync

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: Build and package
+name: Test, build, release
 on: push
 jobs:
   build:
-    name: SkillerWhaleSync
+    name: "Test and build"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +18,7 @@ jobs:
         with:
           path: build
   release:
-    name: "Test and release"
+    name: Release
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -26,16 +26,18 @@ jobs:
         name: Download build
       - name: Display fetched artifacts
         run: ls -R
+      # Release tags that aren't v... are pre-release, named after their branch
       - if: "!startsWith(github.ref, 'refs/tags/v')"
         name: Create pre-release from main
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          automatic_release_tag: "${{ github.ref_name }}"
           prerelease: true
           title: "Development Build"
           files: |
             artifact/SkillerWhaleSync-*
+      # Release tags starting v... are releases, named as per the tag
       - if: "startsWith(github.ref, 'refs/tags/v')"
         name: Create tagged release
         uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image
+name: Build and publish a Docker image
 on: push
 
 env:
@@ -34,10 +34,16 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
+          build-args: |
+            release=${{ github.ref_name }}
           context: .
           platforms: linux/amd64, linux/arm64
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,5 @@
 name: Create and publish a Docker image
-
-on:
-  push:
-    branches: ['main']
+on: push
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt -qq -y install ca-certificates
 EXPOSE 9494
 
 ARG name=SkillerWhaleSync
-ARG version=0.1.2
+ARG version=latest
 ARG TARGETOS
 ENV TARGETOS=${TARGETOS:-linux}
 ARG TARGETARCH
@@ -13,7 +13,7 @@ ENV TARGETARCH=${TARGETARCH:-amd64}
 # RUN apt update && apt -qq -y install curl
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-ADD https://github.com/skiller-whale/learnersync/releases/download/v${version}/${name}-${TARGETOS}-${TARGETARCH} /usr/local/bin/${name}
+ADD https://github.com/skiller-whale/learnersync/releases/download/${version}/${name}-${TARGETOS}-${TARGETARCH} /usr/local/bin/${name}
 # in development: COPY SkillerWhaleSync-linux-amd64 /usr/local/bin/SkillerWhaleSync
 RUN chmod +x /usr/local/bin/$name
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt -qq -y install ca-certificates
 EXPOSE 9494
 
 ARG name=SkillerWhaleSync
-ARG version=latest
+ARG release=latest
 ARG TARGETOS
 ENV TARGETOS=${TARGETOS:-linux}
 ARG TARGETARCH
@@ -13,7 +13,7 @@ ENV TARGETARCH=${TARGETARCH:-amd64}
 # RUN apt update && apt -qq -y install curl
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-ADD https://github.com/skiller-whale/learnersync/releases/download/${version}/${name}-${TARGETOS}-${TARGETARCH} /usr/local/bin/${name}
+ADD https://github.com/skiller-whale/learnersync/releases/download/${release}/${name}-${TARGETOS}-${TARGETARCH} /usr/local/bin/${name}
 # in development: COPY SkillerWhaleSync-linux-amd64 /usr/local/bin/SkillerWhaleSync
 RUN chmod +x /usr/local/bin/$name
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,49 @@ File synchronisation client for Skiller Whale learners
 This program synchronises files up to Skiller Whale as part of a live coaching
 session.
 
-Full usage instructions can be found in [src/main/resources/usage.txt](src/main/resources/usage.txt).
+SkillerWhaleSync scans for changes on a local filesystem and posts them up to
+Skiller Whale for a coach to view during a session.
 
 It is usually set up by curriculum maintainers with docker or integrated into
-the [https://github.com/skiller-whale/learnerhost](hosted learner environment).
+the [https://github.com/skiller-whale/learnerhost](hosted learner environment),
+so this explanation isn't written for learners!
+
 
 ## Building
 
 You can build the program with `go build` or use the `buildAll` script to build for all platforms.
 
 `go test` should be pretty fast to make sure you've not broken anything.
+
+## Supplying the attendance id
+
+Each learner in a coaching session is given an "attendance id", a random number which they need to pass on
+to SkillerWhaleSync.  The program provides three ways of doing this:
+
+1. manually writing it to a file in the exercise folder usually called `attendance_id`
+2. starting the program with the ATTENDANCE_ID parameter (the hosted learner environment does this)
+3. issuing an HTTP GET to `http://localhost:9494/set?id=...&redirect=...` - an experimental half-way house
+   for train to use.
+
+## Polling vs inotify
+
+SkillerWhaleSync uses the Go fsnotify library which asks the OS to call it back when there are file changes.
+This doesn't always work (e.g. on Docker and Windows), so initially the program will also start polling the
+filesystem every 2.5s and report changes that way.
+
+Once a notification has been received, it will disable the less-efficient polling.
+
+But you can force it to poll using the *FORCE_POLL* parameter below.
+
+## Setup
+
+The program is configured through environment variables, only the first of which is compulsory:
+
+* **WATCHED_EXTS**: Space-separated list of file extensions to monitor, all others are ignored e.g. `js ts`.
+* **IGNORE_MATCH**: A space-separated list of patterns to ignore in the full pathname e.g. `.git .DS_Store *.class`.
+* **SERVER_URL**: The URL of the server which has `/pings` and `/file_snapshots` endpoints, defaults to `https://train.skillerwhale.com`.
+* **ATTENDANCE_ID_FILE**: The file in which the user will write their session "attendance_id" supplied by the training interface to identify a particular learner. The program will not start until a valid ID is written to this file.
+* **ATTENDANCE_ID**: Alternatively, you can supply the ID directly and the program will quit if it's not valid.
+* **WATCHED_BASE_PATH**: The directory to monitor for file changes (defaults to `.`).
+* **TRIGGER_EXEC**: A trigger program to run on every file change with the full pathname as its argument.
+* **FORCE_POLL**: Set to "1" to disable inotify usage on the host.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-File synchronisation client for Skiller Whale learners
-======================================================
+# File synchronisation client for Skiller Whale learners
 
 This program synchronises files up to Skiller Whale as part of a live coaching
 session.
@@ -11,6 +10,31 @@ It is usually set up by curriculum maintainers with docker or integrated into
 the [https://github.com/skiller-whale/learnerhost](hosted learner environment),
 so this explanation isn't written for learners!
 
+## Simple integration
+
+For curriculum authors, you add synchronisation to your curriculum by
+including this service in its docker-compose.yml:
+
+```yaml
+  sync:
+    image: "ghcr.io/skiller-whale/learnersync"
+    network_mode: "host"
+    environment:
+      WATCHER_BASE_PATH: "/app/exercises"
+      ATTENDANCE_ID_FILE: "/app/sync/attendance_id"
+      WATCHED_EXTS: "js jsx ts tsx html"
+      IGNORE_DIRS: ".git"
+    volumes:
+      - "./src:/app/exercises/src"
+      - "./attendance_id:/app/sync/attendance_id"
+    tty: true
+    stdin_open: true
+```
+
+This should always reference the latest-tested Docker image.
+
+If you need to test pre-release versions, you can add change the image
+argument to e.g. `gchr.io/skiller-whale/learnersync:pre-release-branch`.
 
 ## Building
 

--- a/learnersync.go
+++ b/learnersync.go
@@ -383,6 +383,11 @@ func InitFromEnv() (s Sync, err error) {
 		return s, err
 	}
 	s.fileUpdated = make(chan string)
+	_, err = httpClient.Get(s.ServerUrl)
+	if err != nil {
+		return s, err
+	}
+	// resp.StatusCode
 
 	if len(s.WatchedExts) == 0 {
 		return s, fmt.Errorf("WATCHED_EXTS not set")

--- a/learnersync.go
+++ b/learnersync.go
@@ -147,6 +147,10 @@ func (s *Sync) postJSON(endpoint, data string) error {
 		return nil
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// log response body
+		defer resp.Body.Close()
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("We tried to post %d bytes to %s but server gave us status %d and body \"%s\"", len(data), endpoint, resp.StatusCode, body[0:100])
 		return CLIENT_ERROR
 	}
 	return SERVER_ERROR

--- a/learnersync.go
+++ b/learnersync.go
@@ -24,7 +24,8 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-const MAX_UPLOAD_BYTES = 10000000
+const MAX_UPLOAD_BYTES = 2000000
+
 const SEND_AFTER_MILLIS = 100
 const PING_EVERY_MILLIS = 2000
 const PING_WARNING_MILLIS = 5000

--- a/learnersync.go
+++ b/learnersync.go
@@ -249,8 +249,8 @@ func (s *Sync) PostFileUpdates() {
 				retries: 0,
 			}
 		case <-nextfileChannel:
+			log.Printf("Posting %s", nextFile)
 			if err := s.PostFile(nextFile); err == nil {
-				log.Printf("Posted %s", nextFile)
 				delete(filesToPostTimes, nextFile)
 				if s.filePosted != nil {
 					s.filePosted <- nextFile

--- a/learnersync.go
+++ b/learnersync.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -29,6 +31,7 @@ const MAX_UPLOAD_BYTES = 2000000
 const SEND_AFTER_MILLIS = 100
 const PING_EVERY_MILLIS = 2000
 const PING_WARNING_MILLIS = 5000
+const POLL_INTERVAL_MILLIS = 2500
 const MAX_RETRY_DELAY = 30000
 const MAX_TRIGGER_TIME = 2500
 
@@ -83,6 +86,40 @@ func decodeBytes(b []byte) string {
 	return string(b) // will soldier on in case of bad encoding
 }
 
+type WatchedFiles map[string]time.Time
+
+func ScanForFiles(dir string, ignoreFilter func(filename string) bool, matchFilter func(filename string) bool) (WatchedFiles, error) {
+	w := make(WatchedFiles)
+
+	return w, filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			log.Printf("%v ignored while traversing %s", err, path)
+			return nil
+		} else if entry.IsDir() {
+			if ignoreFilter(path) {
+				return filepath.SkipDir
+			}
+		} else if entry.Type().IsRegular() && !ignoreFilter(path) && matchFilter(path) {
+			if info, err := entry.Info(); err == nil {
+				w[path] = info.ModTime()
+			} else {
+				log.Printf("%v ignored while reading info for %s", err, path)
+			}
+		}
+		return nil
+	})
+}
+
+func (w WatchedFiles) AddedOrChanged(prev WatchedFiles) (o []string) {
+	o = make([]string, 0)
+	for path, updated := range w {
+		if prev[path].IsZero() || updated.After(prev[path]) {
+			o = append(o, path)
+		}
+	}
+	return o
+}
+
 type Sync struct {
 	ServerUrl        string   `env:"SERVER_URL"         envDefault:"https://train.skillerwhale.com"`
 	AttendanceIdFile string   `env:"ATTENDANCE_ID_FILE" envDefault:"attendance_id"`
@@ -91,10 +128,23 @@ type Sync struct {
 	Ignore           []string `env:"IGNORE_MATCH"       envSeparator:" ""`
 	WatchedExts      []string `env:"WATCHED_EXTS"       envSeparator:" ""`
 	AttendanceId     string   `env:"ATTENDANCE_ID"`
+	ForcePoll        bool     `env:"FORCE_POLL"`
 
-	watcher     *fsnotify.Watcher
+	watcher *fsnotify.Watcher
+
+	noPollSignal chan struct{}
+
 	fileUpdated chan string
 	filePosted  chan string
+}
+
+func (s *Sync) MatchesExts(path string) bool {
+	for _, ext := range s.WatchedExts {
+		if strings.HasSuffix(path, "."+ext) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Sync) Close() {
@@ -190,6 +240,11 @@ func (s *Sync) WaitForFileUpdates() {
 				panic("watcher.Events channel closed unexpectedly")
 			}
 			if event.Has(fsnotify.Write) {
+				if s.noPollSignal != nil {
+					s.noPollSignal <- struct{}{}
+					s.noPollSignal = nil
+				}
+
 				fileInfo, err := os.Stat(event.Name)
 				if err != nil {
 					log.Printf("ignoring change to %s due to %v", event.Name, err)
@@ -197,11 +252,8 @@ func (s *Sync) WaitForFileUpdates() {
 					if fileInfo.IsDir() {
 						s.WatchDirectory(event.Name)
 					} else if fileInfo.Mode().IsRegular() {
-						for _, ext := range s.WatchedExts {
-							if strings.HasSuffix(event.Name, "."+ext) {
-								s.fileUpdated <- event.Name
-								break
-							}
+						if s.MatchesExts(event.Name) {
+							s.fileUpdated <- event.Name
 						}
 					}
 				}
@@ -211,6 +263,31 @@ func (s *Sync) WaitForFileUpdates() {
 				panic("watcher.Errors channel closed unexpectedly")
 			}
 			log.Println("error:", err)
+		}
+	}
+}
+
+func (s *Sync) PollForFileUpdates() {
+	var prev WatchedFiles
+	for {
+		cur, err := ScanForFiles(s.Base, s.ignorable, s.MatchesExts)
+		if err != nil {
+			log.Println("Error scanning for files:", err)
+		}
+		if prev != nil {
+			for _, f := range cur.AddedOrChanged(prev) {
+				s.fileUpdated <- f
+			}
+		} else {
+			log.Println("Now watching", s.Base, "for changes to files with extensions", s.WatchedExts, "which contains", len(cur), "matching files on startup")
+		}
+		prev = cur
+		time.Sleep(POLL_INTERVAL_MILLIS * time.Millisecond)
+		select {
+		case <-s.noPollSignal:
+			log.Println("Polling disabled because we're getting fsnotify events")
+			return
+		default:
 		}
 	}
 }
@@ -335,14 +412,15 @@ func (s *Sync) WaitForAttendanceId() error {
 	}).Serve(listener)
 	defer listener.Close()
 
-	log.Printf("Write attendance_id to local file %s or GET http://localhost:9494/set?id=xxxxxxx&redirect=skillerwhale.com", s.AttendanceIdFile)
-
+	var prompted bool
 	for newId := ""; ; {
 		select {
 		case newId = <-incomingId:
 		case <-time.NewTimer(time.Second / 2).C:
 			newId, err = s.readAttendanceIdFile()
-			fatalIfSet(err)
+			if !errors.Is(err, fs.ErrNotExist) {
+				fatalIfSet(err)
+			}
 		}
 		if newId != s.AttendanceId {
 			s.AttendanceId = newId
@@ -354,6 +432,10 @@ func (s *Sync) WaitForAttendanceId() error {
 			default:
 				return err
 			}
+		}
+		if !prompted {
+			log.Printf("Write attendance_id to local file %s or GET http://localhost:9494/set?id=xxxxxxx&redirect=https://skillerwhale.com/", s.AttendanceIdFile)
+			prompted = true
 		}
 	}
 }
@@ -370,7 +452,10 @@ func (s *Sync) Run() {
 			time.Sleep(time.Duration(PING_EVERY_MILLIS) * time.Millisecond)
 		}
 	})
-	runIt(s.WaitForFileUpdates)
+	runIt(s.PollForFileUpdates)
+	if !s.ForcePoll {
+		runIt(s.WaitForFileUpdates)
+	}
 	runIt(s.PostFileUpdates)
 	if s.TriggerExec != "" {
 		runIt(s.RunTriggers)
@@ -383,6 +468,12 @@ func InitFromEnv() (s Sync, err error) {
 		return s, err
 	}
 	s.fileUpdated = make(chan string)
+	s.noPollSignal = make(chan struct{})
+
+	if s.Base, err = filepath.Abs(s.Base); err != nil {
+		return s, err
+	}
+
 	_, err = httpClient.Get(s.ServerUrl)
 	if err != nil {
 		return s, err
@@ -412,12 +503,13 @@ func InitFromEnv() (s Sync, err error) {
 			return s, err
 		}
 	}
-	if s.Base, err = filepath.Abs(s.Base); err != nil {
-		return s, err
-	}
 
-	if err := s.WatchDirectory(s.Base); err != nil {
-		return s, err
+	if !s.ForcePoll {
+		if err := s.WatchDirectory(s.Base); err != nil {
+			return s, err
+		}
+	} else {
+		log.Println("Forced polling mode, will not try to listen for filesystem events")
 	}
 
 	return s, err

--- a/learnersync.go
+++ b/learnersync.go
@@ -438,6 +438,6 @@ func main() {
 	} else {
 		fatalIfSet(sync.PostPing())
 	}
-	log.Printf("Starting with attendance_id=%s", sync.AttendanceId)
+	log.Println("Valid attendance_id", sync.AttendanceId)
 	sync.Run()
 }


### PR DESCRIPTION
As @davidmillican suggested, this now starts by polling _and_ using fsnotify, and disables polling when fsnotify starts to work. There's no attempt to detect the platform, or knobs to configure it, it just does double the work on startup to determine whether it can skip polling.

There's already debouncing in there, so duplicate signals (close enough together) don't cause duplicate file uploads.

You can test this version in your docker-compose by referencing this branch in the image name e.g.

```yaml
  sync:
    image: ghcr.io/skiller-whale/learnersync:windows-fixes
    network_mode: host
    environment:
      SERVER_URL: https://train.skillerwhale.com/
      WATCHER_BASE_PATH: /app
      ATTENDANCE_ID_FILE: /app/sync/attendance_id
      WATCHED_EXTS: java
      IGNORE_DIRS: .git
    volumes:
      - ./exercises:/app/exercises
      - ./attendance_id:/app/sync/attendance_id
    tty: true
    stdin_open: true
```

There's also an updated README that details how the variables work as @merivale had asked me and it wasn't obvious.