### PR TITLE
Add learnerhost environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ including this service in its docker-compose.yml:
       ATTENDANCE_ID_FILE: "/app/sync/attendance_id"
       WATCHED_EXTS: "js jsx ts tsx html"
       IGNORE_DIRS: ".git"
+      SW_RUNNING_IN_HOSTED_ENV:  # This is set on SW hosted environment machines
     volumes:
       - "./src:/app/exercises/src"
       - "./attendance_id:/app/sync/attendance_id"
@@ -67,6 +68,7 @@ But you can force it to poll using the *FORCE_POLL* parameter below.
 The program is configured through environment variables, only the first of which is compulsory:
 
 * **WATCHED_EXTS**: Space-separated list of file extensions to monitor, all others are ignored e.g. `js ts`.
+* **SW_RUNNING_IN_HOSTED_ENV**:  Will be set to 1 in SW hosted learner environments.
 * **IGNORE_MATCH**: A space-separated list of patterns to ignore in the full pathname e.g. `.git .DS_Store *.class`.
 * **SERVER_URL**: The URL of the server which has `/pings` and `/file_snapshots` endpoints, defaults to `https://train.skillerwhale.com`.
 * **ATTENDANCE_ID_FILE**: The file in which the user will write their session "attendance_id" supplied by the training interface to identify a particular learner. The program will not start until a valid ID is written to this file.

--- a/learnersync.go
+++ b/learnersync.go
@@ -121,13 +121,13 @@ func (w WatchedFiles) AddedOrChanged(prev WatchedFiles) (o []string) {
 }
 
 type Sync struct {
-	ServerUrl        string   `env:"SERVER_URL"         envDefault:"https://train.skillerwhale.com"`
-	InHostedEnv      bool     // TODO: Read this from the environment
-	AttendanceIdFile string   `env:"ATTENDANCE_ID_FILE" envDefault:"attendance_id"`
-	Base             string   `env:"WATCHER_BASE_PATH"  envDefault:"."`
+	ServerUrl        string   `env:"SERVER_URL"               envDefault:"https://train.skillerwhale.com"`
+	InHostedEnv      bool     `env:"SW_RUNNING_IN_HOSTED_ENV" envDefault:"0"`
+	AttendanceIdFile string   `env:"ATTENDANCE_ID_FILE"       envDefault:"attendance_id"`
+	Base             string   `env:"WATCHER_BASE_PATH"        envDefault:"."`
 	TriggerExec      string   `env:"TRIGGER_EXEC"`
-	Ignore           []string `env:"IGNORE_MATCH"       envSeparator:" ""`
-	WatchedExts      []string `env:"WATCHED_EXTS"       envSeparator:" ""`
+	Ignore           []string `env:"IGNORE_MATCH"             envSeparator:" ""`
+	WatchedExts      []string `env:"WATCHED_EXTS"             envSeparator:" ""`
 	AttendanceId     string   `env:"ATTENDANCE_ID"`
 	ForcePoll        bool     `env:"FORCE_POLL"`
 

--- a/learnersync.go
+++ b/learnersync.go
@@ -232,9 +232,11 @@ func (s *Sync) PostFile(path string) error {
 		struct {
 			RelativePath string `json:"relative_path"`
 			Contents     string `json:"contents"`
+			InHostedEnv  bool   `json:"sent_from_hosted_environment"`
 		}{
 			strings.TrimPrefix(path, s.Base),
 			decodeBytes(contents),
+			s.InHostedEnv,
 		},
 	)
 	fatalIfSet(err)

--- a/learnersync.go
+++ b/learnersync.go
@@ -122,6 +122,7 @@ func (w WatchedFiles) AddedOrChanged(prev WatchedFiles) (o []string) {
 
 type Sync struct {
 	ServerUrl        string   `env:"SERVER_URL"         envDefault:"https://train.skillerwhale.com"`
+	InHostedEnv      bool     // TODO: Read this from the environment
 	AttendanceIdFile string   `env:"ATTENDANCE_ID_FILE" envDefault:"attendance_id"`
 	Base             string   `env:"WATCHER_BASE_PATH"  envDefault:"."`
 	TriggerExec      string   `env:"TRIGGER_EXEC"`

--- a/learnersync.go
+++ b/learnersync.go
@@ -208,7 +208,15 @@ func (s *Sync) postJSON(endpoint, data string) error {
 }
 
 func (s *Sync) PostPing() error {
-	return s.postJSON("pings", "")
+	body, err := json.Marshal(
+		struct {
+			InHostedEnv bool `json:"sent_from_hosted_environment"`
+		}{
+			s.InHostedEnv,
+		},
+	)
+	fatalIfSet(err)
+	return s.postJSON("pings", string(body))
 }
 
 func (s *Sync) PostFile(path string) error {

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -114,6 +114,44 @@ func TestHTTPFunctions(t *testing.T) {
 	// 0-length file should not cause a Post, how to test
 }
 
+type HLEParameterTest = struct {
+	setEnv func(s *Sync)
+	expected  bool
+}
+
+var HLEParameterTests = []HLEParameterTest{
+	{func(s *Sync) { s.InHostedEnv = false }, false},
+	{func(s *Sync) { s.InHostedEnv = true }, true},
+}
+
+func TestPostPingUsesHostedEnvironmentEnvvar(t *testing.T) {
+	server, reqs, sync := mockServerAndSync()
+	defer server.Close()
+
+	for _, test := range HLEParameterTests {
+		test.setEnv(sync) // set up the hosted learner environment env var
+
+		if err := sync.PostPing(); err != nil {
+			t.Fatalf("ping didn't work: %v", err)
+		}
+
+		if r, ok := <-reqs; !ok {
+			t.Fatal("no request sent by PostPing")
+		} else {
+			decoder := json.NewDecoder(bytes.NewReader(r.body))
+			j := struct {
+				SentFromHostedEnvironment bool `json:"sent_from_hosted_environment"`
+			}{}
+			if err := decoder.Decode(&j); err != nil {
+				t.Fatal("couldn't decode json", err)
+			}
+			if j.SentFromHostedEnvironment != test.expected {
+				t.Fatal("wrong value for sent from hosted environment", j.SentFromHostedEnvironment, "not", test.expected)
+			}
+		}
+	}
+}
+
 func TestFSEvents(t *testing.T) {
 	dir := fmt.Sprintf("%s/testFsEvents.%d.%d", os.TempDir(), os.Getpid(), rand.Int())
 	fatalIfSet(os.Mkdir(dir, 0755))

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -152,6 +152,45 @@ func TestPostPingUsesHostedEnvironmentEnvvar(t *testing.T) {
 	}
 }
 
+func TestPostFileUsesHostedEnvironmentEnvvar(t *testing.T) {
+	server, reqs, sync := mockServerAndSync()
+	defer server.Close()
+
+	for _, test := range HLEParameterTests {
+		test.setEnv(sync) // set up the hosted learner environment env var
+
+		var filename string
+		if f, err := os.CreateTemp("", "topost"); err != nil {
+			panic(err)
+		} else {
+			defer os.Remove(f.Name())
+			f.Write(([]byte)("Hello\nThere\t\t😀"))
+			f.Close()
+			filename = f.Name()
+		}
+
+		if err := sync.PostFile(filename); err != nil {
+			t.Fatalf("Posting file didn't work: %v", err)
+		}
+
+		if r, ok := <-reqs; !ok {
+			t.Fatal("no request sent by PostFile")
+		} else {
+
+			decoder := json.NewDecoder(bytes.NewReader(r.body))
+			j := struct {
+				SentFromHostedEnvironment bool `json:"sent_from_hosted_environment"`
+			}{}
+			if err := decoder.Decode(&j); err != nil {
+				t.Fatal("couldn't decode json request", err)
+			}
+			if j.SentFromHostedEnvironment != test.expected {
+				t.Fatal("wrong value for sent from hosted environment", j.SentFromHostedEnvironment, "not", test.expected)
+			}
+		}
+	}
+}
+
 func TestFSEvents(t *testing.T) {
 	dir := fmt.Sprintf("%s/testFsEvents.%d.%d", os.TempDir(), os.Getpid(), rand.Int())
 	fatalIfSet(os.Mkdir(dir, 0755))


### PR DESCRIPTION
This PR adds a parameter, `sent_from_hosted_environment` to the `PostPing` and `PostFile` requests
to indicate whether the machine the sync is running on has the `SW_RUNNING_IN_HOSTED_ENV` 
environment variable set or not. 

This will allow the coach (and us in our logs) to see whether the sync / files are sent from the hosted env.

I've tried to avoid any unnecessary refactors, and mostly just add new code to the tests (which will 
hopefully reduce any merge conflicts).  Should hopefully be clear enough to review commit by commit.