### PR TITLE
Update to latest version of docker-login-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
This shouldn't have any breaking changes, but switches to released versions, 
rather than pinning to a specific commit. The previous commit was merged to 
`main` in 2021, and v3 is well beyond this.

Note: Review after #11 to avoid build errors.