### PR TITLE
Allow watching extensionless files (e.g. Dockerfile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ But you can force it to poll using the *FORCE_POLL* parameter below.
 
 The program is configured through environment variables, only the first of which is compulsory:
 
-* **WATCHED_EXTS**: Space-separated list of file extensions to monitor, all others are ignored e.g. `js ts`.
+* **WATCHED_EXTS**: Space-separated list of file extensions to monitor, all others are ignored, for example `.js .ts`.
+  * For specifically named files with no extension, you should just include the filename e.g. `.js Dockerfile .ts`.
+  * _legacy: extensions can omit the leading `.`, and files will still be matched. For example `js ts` would match `.js` or `.ts` files. This behaviour will be deprecated in the future to remove ambiguity (e.g. between a file called `js` and a file called `example.js`)_
 * **SW_RUNNING_IN_HOSTED_ENV**:  Will be set to 1 in SW hosted learner environments.
 * **IGNORE_MATCH**: A space-separated list of patterns to ignore in the full pathname e.g. `.git .DS_Store *.class`.
 * **SERVER_URL**: The URL of the server which has `/pings` and `/file_snapshots` endpoints, defaults to `https://train.skillerwhale.com`.

--- a/learnersync.go
+++ b/learnersync.go
@@ -143,15 +143,20 @@ func (s *Sync) MatchesExts(path string) bool {
 	if ext := filepath.Ext(path); len(ext) > 0 {
 		// The path has an extension, try matching this.
 		return s.isEqualToWatchedExtension(ext[1:])
-
 	} else {
 		// There is no extension, try matching the complete filename instead (e.g. Dockerfile)
 		return s.isEqualToWatchedExtension(filepath.Base(path))
 	}
 }
 
+// isEqualToWatchedExtension returns true if the given string matches any of the
+// extensions in the WatchedExts list. The passed string should not include a
+// leading period.
 func (s *Sync) isEqualToWatchedExtension(str string) bool {
 	for _, ext := range s.WatchedExts {
+		if len(ext) > 0 && ext[0] == '.' {
+			ext = ext[1:] // strip leading period if present
+		}
 		if str == ext {
 			return true // the extension is an exact match
 		}

--- a/learnersync.go
+++ b/learnersync.go
@@ -140,9 +140,20 @@ type Sync struct {
 }
 
 func (s *Sync) MatchesExts(path string) bool {
+	if ext := filepath.Ext(path); len(ext) > 0 {
+		// The path has an extension, try matching this.
+		return s.isEqualToWatchedExtension(ext[1:])
+
+	} else {
+		// There is no extension, try matching the complete filename instead (e.g. Dockerfile)
+		return s.isEqualToWatchedExtension(filepath.Base(path))
+	}
+}
+
+func (s *Sync) isEqualToWatchedExtension(str string) bool {
 	for _, ext := range s.WatchedExts {
-		if strings.HasSuffix(path, "."+ext) {
-			return true
+		if str == ext {
+			return true // the extension is an exact match
 		}
 	}
 	return false

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -22,18 +22,18 @@ type MatchesExtTest = struct {
 }
 
 var MatchesExtTests = []MatchesExtTest{
-	{[]string{}, "file.js", false},                           // no watched extensions
-	{[]string{""}, "file.js", false},                         // empty watched extension
-	{[]string{"js"}, "file.js", true},                        // single watched extension
-	{[]string{"js"}, "", false},                        		  // empty path
-	{[]string{"js"}, "/a/long/path/file.js", true},           // single watched extension with longer path
-	{[]string{"js"}, ".js", true},                            // no filename before .
-	{[]string{"longext", "js"}, "file.js", true},             // multiple watched extensions
-	{[]string{"longext", "js"}, "longext.file", false},       // string match elsewhere in path
-	{[]string{"longext", "js"}, "file.long", false},          // partial extension match
-	{[]string{"Dockerfile"}, "Dockerfile", false},            // file with no extension
-	{[]string{"Dockerfile"}, "/Dockerfile", false},           // file with no extension
-	{[]string{"Dockerfile"}, "/some/path/Dockerfile", false}, // file with no extension
+	{[]string{}, "file.js", false},                          // no watched extensions
+	{[]string{""}, "file.js", false},                        // empty watched extension
+	{[]string{"js"}, "file.js", true},                       // single watched extension
+	{[]string{"js"}, "", false},                             // empty path
+	{[]string{"js"}, "/a/long/path/file.js", true},          // single watched extension with longer path
+	{[]string{"js"}, ".js", true},                           // no filename before .
+	{[]string{"longext", "js"}, "file.js", true},            // multiple watched extensions
+	{[]string{"longext", "js"}, "longext.file", false},      // string match elsewhere in path
+	{[]string{"longext", "js"}, "file.long", false},         // partial extension match
+	{[]string{"Dockerfile"}, "Dockerfile", true},            // file with no extension
+	{[]string{"Dockerfile"}, "/Dockerfile", true},           // file with no extension
+	{[]string{"Dockerfile"}, "/some/path/Dockerfile", true}, // file with no extension
 }
 
 func TestMatchesExts(t *testing.T) {

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -15,6 +15,38 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+type MatchesExtTest = struct {
+	watchedExts []string
+	path        string
+	expected    bool
+}
+
+var MatchesExtTests = []MatchesExtTest{
+	{[]string{}, "file.js", false},                           // no watched extensions
+	{[]string{""}, "file.js", false},                         // empty watched extension
+	{[]string{"js"}, "file.js", true},                        // single watched extension
+	{[]string{"js"}, "", false},                        		  // empty path
+	{[]string{"js"}, "/a/long/path/file.js", true},           // single watched extension with longer path
+	{[]string{"js"}, ".js", true},                            // no filename before .
+	{[]string{"longext", "js"}, "file.js", true},             // multiple watched extensions
+	{[]string{"longext", "js"}, "longext.file", false},       // string match elsewhere in path
+	{[]string{"longext", "js"}, "file.long", false},          // partial extension match
+	{[]string{"Dockerfile"}, "Dockerfile", false},            // file with no extension
+	{[]string{"Dockerfile"}, "/Dockerfile", false},           // file with no extension
+	{[]string{"Dockerfile"}, "/some/path/Dockerfile", false}, // file with no extension
+}
+
+func TestMatchesExts(t *testing.T) {
+	for _, test := range MatchesExtTests {
+		s := Sync{
+			WatchedExts: test.watchedExts,
+		}
+		if s.MatchesExts(test.path) != test.expected {
+			t.Fatal("matchesExt failed for", test.path, "with watchedExts", test.watchedExts)
+		}
+	}
+}
+
 func TestIgnorable(t *testing.T) {
 	s := Sync{
 		Ignore: []string{"*/.foo/*"},
@@ -115,8 +147,8 @@ func TestHTTPFunctions(t *testing.T) {
 }
 
 type HLEParameterTest = struct {
-	setEnv func(s *Sync)
-	expected  bool
+	setEnv   func(s *Sync)
+	expected bool
 }
 
 var HLEParameterTests = []HLEParameterTest{

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -34,6 +34,7 @@ var MatchesExtTests = []MatchesExtTest{
 	{[]string{"Dockerfile"}, "Dockerfile", true},            // file with no extension
 	{[]string{"Dockerfile"}, "/Dockerfile", true},           // file with no extension
 	{[]string{"Dockerfile"}, "/some/path/Dockerfile", true}, // file with no extension
+	{[]string{".js"}, "file.js", true},                      // with period included
 }
 
 func TestMatchesExts(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/skiller-whale/learnersync/issues/7

This PR updates the `MatchesExts` function to allow watched extensions to match entire filenames
if those files don't have an additional extension. 

This could cause weird edge cases (e.g. if somebody creates a file called `js` rather than `something.js`
then it would be synced. But if they are doing that, then it might be useful for the coach to know about
anyway, and is unlikely to be a huge problem I think.