### PR TITLE
Allocate different available port per test

### DIFF
--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -72,6 +72,9 @@ type cachedHttpRequest struct {
 }
 
 func mockServerAndSync() (*http.Server, chan cachedHttpRequest, *Sync) {
+	// Cycle through available ports to ensure no clashes or delays between tests.
+	// We could alternatively try keeping the port the same but setting
+	// SO_REUSEADDR on the TCP listener.
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -72,10 +72,12 @@ type cachedHttpRequest struct {
 }
 
 func mockServerAndSync() (*http.Server, chan cachedHttpRequest, *Sync) {
-	l, err := net.Listen("tcp", ":8901")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)
 	}
+	port := l.Addr().(*net.TCPAddr).Port
+
 	c := make(chan cachedHttpRequest, 1)
 	s := http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -91,7 +93,8 @@ func mockServerAndSync() (*http.Server, chan cachedHttpRequest, *Sync) {
 		}),
 	}
 	go s.Serve(l)
-	return &s, c, &Sync{ServerUrl: "http://localhost:8901"}
+
+	return &s, c, &Sync{ServerUrl: fmt.Sprintf("http://localhost:%v", port)}
 }
 
 func TestHTTPFunctions(t *testing.T) {


### PR DESCRIPTION
Previously, tests were failing for the second test to use the mocked server. 
A `time.Sleep` solved this, so my theory is that the previous server shutdown 
was interfering in some way with the setup of the new one. 

By allocating a different random available port each time we will hopefully solve 
this issue.