### PR TITLE
Require periods for file extensions

### DIFF
--- a/learnersync.go
+++ b/learnersync.go
@@ -142,7 +142,7 @@ type Sync struct {
 func (s *Sync) MatchesExts(path string) bool {
 	if ext := filepath.Ext(path); len(ext) > 0 {
 		// The path has an extension, try matching this.
-		return s.isEqualToWatchedExtension(ext[1:])
+		return s.isEqualToWatchedExtension(ext)
 	} else {
 		// There is no extension, try matching the complete filename instead (e.g. Dockerfile)
 		return s.isEqualToWatchedExtension(filepath.Base(path))
@@ -150,13 +150,11 @@ func (s *Sync) MatchesExts(path string) bool {
 }
 
 // isEqualToWatchedExtension returns true if the given string matches any of the
-// extensions in the WatchedExts list. The passed string should not include a
-// leading period.
+// extensions in the WatchedExts list. The passed string should include a
+// leading period for extensions, and omit the leading period for filenames
+// with no extension (e.g. Dockerfile)
 func (s *Sync) isEqualToWatchedExtension(str string) bool {
 	for _, ext := range s.WatchedExts {
-		if len(ext) > 0 && ext[0] == '.' {
-			ext = ext[1:] // strip leading period if present
-		}
 		if str == ext {
 			return true // the extension is an exact match
 		}

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -24,13 +24,13 @@ type MatchesExtTest = struct {
 var MatchesExtTests = []MatchesExtTest{
 	{[]string{}, "file.js", false},                          // no watched extensions
 	{[]string{""}, "file.js", false},                        // empty watched extension
-	{[]string{"js"}, "file.js", true},                       // single watched extension
-	{[]string{"js"}, "", false},                             // empty path
-	{[]string{"js"}, "/a/long/path/file.js", true},          // single watched extension with longer path
-	{[]string{"js"}, ".js", true},                           // no filename before .
-	{[]string{"longext", "js"}, "file.js", true},            // multiple watched extensions
-	{[]string{"longext", "js"}, "longext.file", false},      // string match elsewhere in path
-	{[]string{"longext", "js"}, "file.long", false},         // partial extension match
+	{[]string{"js"}, "file.js", false},                      // watched extension without period
+	{[]string{".js"}, "", false},                            // empty path
+	{[]string{".js"}, "/a/long/path/file.js", true},         // single watched extension with longer path
+	{[]string{".js"}, ".js", true},                          // no filename before .
+	{[]string{"longext", ".js"}, "file.js", true},           // multiple watched extensions
+	{[]string{"longext", ".js"}, "longext.file", false},     // string match elsewhere in path
+	{[]string{"longext", ".js"}, "file.long", false},        // partial extension match
 	{[]string{"Dockerfile"}, "Dockerfile", true},            // file with no extension
 	{[]string{"Dockerfile"}, "/Dockerfile", true},           // file with no extension
 	{[]string{"Dockerfile"}, "/some/path/Dockerfile", true}, // file with no extension

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -25,6 +25,7 @@ var MatchesExtTests = []MatchesExtTest{
 	{[]string{}, "file.js", false},                          // no watched extensions
 	{[]string{""}, "file.js", false},                        // empty watched extension
 	{[]string{"js"}, "file.js", false},                      // watched extension without period
+	{[]string{".js"}, "file.js", true},                      // with period included
 	{[]string{".js"}, "", false},                            // empty path
 	{[]string{".js"}, "/a/long/path/file.js", true},         // single watched extension with longer path
 	{[]string{".js"}, ".js", true},                          // no filename before .
@@ -34,7 +35,6 @@ var MatchesExtTests = []MatchesExtTest{
 	{[]string{"Dockerfile"}, "Dockerfile", true},            // file with no extension
 	{[]string{"Dockerfile"}, "/Dockerfile", true},           // file with no extension
 	{[]string{"Dockerfile"}, "/some/path/Dockerfile", true}, // file with no extension
-	{[]string{".js"}, "file.js", true},                      // with period included
 }
 
 func TestMatchesExts(t *testing.T) {


### PR DESCRIPTION
# CONTAINS A BREAKING CHANGE - CAREFUL BEFORE MERGING!

This PR updates the learnersync so that it requires periods in the watched extensions variable.
This means that the specified extension`.js` will match the file `test.js`, but `js` will not.

Similarly, `Dockerfile` will match `Dockerfile`, but not `.Dockerfile`.

We should be a little bit cautious about merging this, as it is a breaking change. People with
an old version of a `docker-compose` file which does not specify a version of learnersync
and has extensions specified without periods might find that their extensions are no longer 
watched correctly (if they end up pulling the latest learnersync). 

This problem should be relatively easy to recover from, but to minimise disruption I suggest
we merge this in a little while. 

`docker-compose` files for our public repos were all updated in early April 2024 to include
the periods before extensions, so this change should be merged a few months after that.