### PR TITLE
update release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,21 +35,25 @@ jobs:
       # Release tags that aren't v... are pre-release, named after their branch
       - if: "!startsWith(github.ref, 'refs/tags/v')"
         name: Create pre-release from main
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "softprops/action-gh-release@v2"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          target_commitish: ${{github.ref_name}}
           automatic_release_tag: "PRERELEASE-${{ github.ref_name }}"
           prerelease: true
-          title: "Development Build"
+          name: "Development build"
+          generate_release_notes: true
           files: |
             artifact/SkillerWhaleSync-*
       # Release tags starting v... are releases, named as per the tag
       - if: "startsWith(github.ref, 'refs/tags/v')"
         name: Create tagged release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "softprops/action-gh-release@v2"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
+          generate_release_notes: true
+          make_latest: true
+          token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
             artifact/SkillerWhaleSync-*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
+          # this uses &&/|| as a ternary: if the ref isn't a tag starting with `v` then the prefix 'PRELEASE-' is added, if not no prefix added
+          # see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example
           build-args: |
-            release=PRERELEASE-${{ github.ref_name }}
+            release=${{ !startsWith(github.ref, 'refs/tags/v') && 'PRERELEASE-' || '' }}${{ github.ref_name }}
           context: .
           platforms: linux/amd64, linux/arm64
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           target_commitish: ${{github.ref_name}}
-          automatic_release_tag: "PRERELEASE-${{ github.ref_name }}"
+          tag_name: "PRERELEASE-${{ github.ref_name }}"
           prerelease: true
           name: "Development build"
           generate_release_notes: true


### PR DESCRIPTION
This switches the action we use for generating releases to a supported one.

It also fixes (i think) the release name passed into the docker build.

The dev version seems to work ok (the generated changelog isn't so helpful, but that's now controlled by github. It should (I think) do the right thing and generate based on most recent non-dev release but I'm not quite sure (and release notes can be edited after the fact)