### PR TITLE
shrink docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bookworm-slim
 RUN apt update && apt -qq -y install ca-certificates
 
 EXPOSE 9494

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bookworm-slim
-RUN apt update && apt -qq -y install ca-certificates
+RUN apt update && apt -qq -y install ca-certificates && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 9494
 


### PR DESCRIPTION
This is some low hanging fruit to make the docker image smaller:
- use the slim version of the debian image
- remove apt data from the final image

This reduces the (uncompressed) image size from ~ 160Mb to ~100Mb