### PR TITLE
fix: Update path matching so folders with a trailing slash are ignored.

### DIFF
--- a/learnersync.go
+++ b/learnersync.go
@@ -182,14 +182,7 @@ func (s *Sync) ignorable(path string) bool {
 		// If pattern doesn't contain wildcards, also check if it matches any path component
 		// This allows "node_modules" to match "/app/exercises/node_modules" and files within it
 		if !strings.ContainsAny(pattern, "*?[") {
-			// Check if the pattern matches the full path or any component
-			for _, component := range strings.Split(path, string(filepath.Separator)) {
-				if component == pattern {
-					return true
-				}
-			}
-			// Also check if the pattern appears as a path component followed by more path
-			// e.g., "node_modules" should match "/app/node_modules/foo"
+			// Check if the pattern appears as a path component in the middle (e.g., "/app/node_modules/foo")
 			pathWithSep := string(filepath.Separator) + pattern + string(filepath.Separator)
 			if strings.Contains(path, pathWithSep) {
 				return true

--- a/learnersync.go
+++ b/learnersync.go
@@ -26,6 +26,7 @@ import (
 )
 
 const MAX_UPLOAD_BYTES = 2000000
+const pathSep = "/"
 
 const SEND_AFTER_MILLIS = 100
 const PING_EVERY_MILLIS = 2000
@@ -183,20 +184,20 @@ func (s *Sync) ignorable(path string) bool {
 		// Wildcard patterns are already handled correctly by filepath.Match above.
 		if !strings.Contains(pattern, "*") {
 			// If pattern starts with /, it should only match at the root
-			if strings.HasPrefix(pattern, string(filepath.Separator)) {
+			if strings.HasPrefix(pattern, pathSep) {
 				// Match paths that start with the pattern (e.g., "/lib" matches "/lib/file.js")
-				if strings.HasPrefix(path, pattern+string(filepath.Separator)) || path == pattern {
+				if strings.HasPrefix(path, pattern+pathSep) || path == pattern {
 					return true
 				}
 			} else {
 				// Pattern without leading slash matches anywhere in the path
 				// Check if the pattern appears as a path component in the middle (e.g., "/app/node_modules/foo")
-				pathWithSep := string(filepath.Separator) + pattern + string(filepath.Separator)
+				pathWithSep := pathSep + pattern + pathSep
 				if strings.Contains(path, pathWithSep) {
 					return true
 				}
 				// Check if path ends with the pattern (e.g., "/app/exercises/node_modules")
-				pathEndsWith := string(filepath.Separator) + pattern
+				pathEndsWith := pathSep + pattern
 				if strings.HasSuffix(path, pathEndsWith) {
 					return true
 				}

--- a/learnersync.go
+++ b/learnersync.go
@@ -179,18 +179,27 @@ func (s *Sync) ignorable(path string) bool {
 			return true
 		}
 
-		// If pattern doesn't contain wildcards, also check if it matches any path component
-		// This allows "node_modules" to match "/app/exercises/node_modules" and files within it
-		if !strings.ContainsAny(pattern, "*?[") {
-			// Check if the pattern appears as a path component in the middle (e.g., "/app/node_modules/foo")
-			pathWithSep := string(filepath.Separator) + pattern + string(filepath.Separator)
-			if strings.Contains(path, pathWithSep) {
-				return true
-			}
-			// Check if path ends with the pattern (e.g., "/app/exercises/node_modules")
-			pathEndsWith := string(filepath.Separator) + pattern
-			if strings.HasSuffix(path, pathEndsWith) {
-				return true
+		// For literal patterns (no wildcards), check if they match as path components.
+		// Wildcard patterns are already handled correctly by filepath.Match above.
+		if !strings.Contains(pattern, "*") {
+			// If pattern starts with /, it should only match at the root
+			if strings.HasPrefix(pattern, string(filepath.Separator)) {
+				// Match paths that start with the pattern (e.g., "/lib" matches "/lib/file.js")
+				if strings.HasPrefix(path, pattern+string(filepath.Separator)) || path == pattern {
+					return true
+				}
+			} else {
+				// Pattern without leading slash matches anywhere in the path
+				// Check if the pattern appears as a path component in the middle (e.g., "/app/node_modules/foo")
+				pathWithSep := string(filepath.Separator) + pattern + string(filepath.Separator)
+				if strings.Contains(path, pathWithSep) {
+					return true
+				}
+				// Check if path ends with the pattern (e.g., "/app/exercises/node_modules")
+				pathEndsWith := string(filepath.Separator) + pattern
+				if strings.HasSuffix(path, pathEndsWith) {
+					return true
+				}
 			}
 		}
 	}

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -64,6 +64,76 @@ func TestIgnorable(t *testing.T) {
 	}
 }
 
+func TestIgnorableWithTrailingSlash(t *testing.T) {
+	testCases := []struct {
+		pattern       string
+		shouldIgnore  []string
+		shouldNotIgnore []string
+	}{
+		{
+			pattern: "node_modules/",
+			shouldIgnore: []string{
+				"/app/exercises/node_modules",
+				"/app/exercises/src/node_modules",
+				"/app/exercises/node_modules/package",
+				"/app/exercises/node_modules/package/file.js",
+			},
+			shouldNotIgnore: []string{
+				"/app/exercises/src",
+				"/app/exercises/my_node_modules",
+				"/app/exercises/not_node_modules",
+				"/app/exercises/node_modules_backup",
+			},
+		},
+		{
+			pattern: "bin/",
+			shouldIgnore: []string{
+				"/app/exercises/bin",
+				"/app/exercises/project/bin",
+				"/app/exercises/bin/output.dll",
+			},
+			shouldNotIgnore: []string{
+				"/app/exercises/binary",
+				"/app/exercises/combined",
+				"/app/exercises/robin",
+				"/app/exercises/robin/file.js",
+			},
+		},
+		{
+			pattern: "obj/",
+			shouldIgnore: []string{
+				"/app/exercises/obj",
+				"/app/exercises/project/obj",
+				"/app/exercises/obj/Debug",
+			},
+			shouldNotIgnore: []string{
+				"/app/exercises/object",
+				"/app/exercises/src",
+				"/app/exercises/objection",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s := Sync{
+			Ignore: []string{tc.pattern},
+		}
+
+		for _, path := range tc.shouldIgnore {
+			if !s.ignorable(path) {
+				t.Errorf("Pattern %q should ignore %q but didn't", tc.pattern, path)
+			}
+		}
+
+		for _, path := range tc.shouldNotIgnore {
+			if s.ignorable(path) {
+				t.Errorf("Pattern %q should NOT ignore %q but did", tc.pattern, path)
+			}
+		}
+	}
+}
+
+
 // utility for initialising a Sync alongside a test web server
 // returns a listening web server, a channel on which all incoming requests can be read, and a matching Sync object which will connect to it.
 type cachedHttpRequest struct {

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -133,6 +133,73 @@ func TestIgnorableWithTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestIgnorableWithLeadingSlash(t *testing.T) {
+	testCases := []struct {
+		pattern         string
+		shouldIgnore    []string
+		shouldNotIgnore []string
+	}{
+		{
+			pattern: "/lib",
+			shouldIgnore: []string{
+				"/lib",
+				"/lib/file.js",
+				"/lib/nested/file.js",
+			},
+			shouldNotIgnore: []string{
+				"/app/lib",
+				"/app/lib/file.js",
+				"/app/exercises/lib",
+				"/app/exercises/lib/file.js",
+			},
+		},
+		{
+			pattern: "/lib/",
+			shouldIgnore: []string{
+				"/lib",
+				"/lib/file.js",
+				"/lib/nested/file.js",
+			},
+			shouldNotIgnore: []string{
+				"/app/lib",
+				"/app/lib/file.js",
+				"/app/exercises/lib",
+				"/app/exercises/lib/file.js",
+			},
+		},
+		{
+			pattern: "/node_modules",
+			shouldIgnore: []string{
+				"/node_modules",
+				"/node_modules/package",
+				"/node_modules/package/file.js",
+			},
+			shouldNotIgnore: []string{
+				"/app/node_modules",
+				"/app/node_modules/file.js",
+				"/app/exercises/node_modules",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s := Sync{
+			Ignore: []string{tc.pattern},
+		}
+
+		for _, path := range tc.shouldIgnore {
+			if !s.ignorable(path) {
+				t.Errorf("Pattern %q should ignore %q but didn't", tc.pattern, path)
+			}
+		}
+
+		for _, path := range tc.shouldNotIgnore {
+			if s.ignorable(path) {
+				t.Errorf("Pattern %q should NOT ignore %q but did", tc.pattern, path)
+			}
+		}
+	}
+}
 
 // utility for initialising a Sync alongside a test web server
 // returns a listening web server, a channel on which all incoming requests can be read, and a matching Sync object which will connect to it.


### PR DESCRIPTION
Updated the logic to work with folders with trailing slashes.  The failing test (see first commit) now passes and we haven't broken anything.   May just want to check we're ok with the folder being matched anywhere - but tests seem pretty clear.  This should match gitignore syntax.