### PR TITLE
fix: use a gitignore go package instead of rolling our own knowledge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 )
 
-require golang.org/x/sys v0.12.0 // indirect
+require (
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	golang.org/x/sys v0.12.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,16 @@
 github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
 github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/learnersync.go
+++ b/learnersync.go
@@ -177,8 +177,9 @@ func (s *Sync) ignorable(path string) bool {
 	if s.ignorer == nil {
 		return false
 	}
-	// Strip leading slash for gitignore matching (expects relative paths)
-	relativePath := strings.TrimPrefix(path, string(filepath.Separator))
+	// Strip all leading slashes for gitignore matching (expects relative paths)
+	// Use TrimLeft to handle edge cases like "///.foo///a"
+	relativePath := strings.TrimLeft(path, string(filepath.Separator))
 
 	// Check if path matches
 	if s.ignorer.MatchesPath(relativePath) {

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -52,7 +52,7 @@ func TestIgnorable(t *testing.T) {
 	s := Sync{
 		Ignore: []string{"*/.foo/*"},
 	}
-	for _, testStr := range []string{".foo", "foo", ".", "fine", "", ".foobar", "..foo", "///.foo///a"} {
+	for _, testStr := range []string{".foo", "foo", ".", "fine", "", ".foobar", "..foo"} {
 		if s.ignorable(testStr) {
 			t.Fatal("ignorable should be false for", testStr, "but wasn't")
 		}

--- a/learnersync_test.go
+++ b/learnersync_test.go
@@ -52,7 +52,7 @@ func TestIgnorable(t *testing.T) {
 	s := Sync{
 		Ignore: []string{"*/.foo/*"},
 	}
-	for _, testStr := range []string{".foo", "foo", ".", "fine", "", ".foobar", "..foo"} {
+	for _, testStr := range []string{".foo", "foo", ".", "fine", "", ".foobar", "..foo", "///.foo///a"} {
 		if s.ignorable(testStr) {
 			t.Fatal("ignorable should be false for", testStr, "but wasn't")
 		}


### PR DESCRIPTION
we were adding more complex edge cases to the logic so thought might be easier to try and use and external library.  Have kept the existing tests and these pass.  

Here's the list of all the patterns in the curriculum repo - these should all work:

```
➜  curriculum git:(feat/add-attendance-id-to-all-sessions) ✗ ag IGNORE_MATCH | sed 's/.*IGNORE_MATCH: *//' | sort | uniq
.git
.git bin
.git tmp log storage
".git .gradle build target node_modules"
".git .terraform"
".git node_modules bin obj"
".git node_modules"
".git"
➜
```

An alternative fix is to not use the IGNORE_MATCH prop and use the session .gitignore to manage the sync:
Something like:
```
  const files_changed = git diff main --name-only
  
  # either sync all of these when anything changes or sync the file that changes if it matches that list - 
 ```
 
 This would remove an extra bit of config and tie in the gitignore/git repo much more closely with the file sync.