### PR TITLE
fix: bump limit on coach attendance id

### DIFF
--- a/learnersync.go
+++ b/learnersync.go
@@ -444,7 +444,7 @@ func (s *Sync) RunTriggers() {
 }
 
 func (s *Sync) readAttendanceIdFile() (string, error) {
-	contents, err := readFileMax(s.AttendanceIdFile, 100)
+	contents, err := readFileMax(s.AttendanceIdFile, 3000)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The coach attendance id is sometimes too big which causes the learner sync to fail.

This is the attendance id for the coach from a previous session
<img width="1006" height="108" alt="image" src="https://github.com/user-attachments/assets/c778a992-62f8-4381-911d-fd86354645d1" />
