### PR TITLE
feat/docker for better testing

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+ARG TARGETARCH
+RUN apt-get update && \
+    apt-get install -y wget ca-certificates gcc libc6-dev && \
+    ARCH=$(dpkg --print-architecture) && \
+    wget -q https://go.dev/dl/go1.18.10.linux-${ARCH}.tar.gz && \
+    tar -C /usr/local -xzf go1.18.10.linux-${ARCH}.tar.gz && \
+    rm go1.18.10.linux-${ARCH}.tar.gz && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Default command runs all tests
+CMD ["go", "test", "-v", "./..."]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ You can fix this by running the go generate command to create an (untracked) fil
 go generate
 ```
 
+### Testing on Linux
+
+Some tests behave differently on Linux vs macOS due to platform-specific filesystem notification implementations (inotify vs kqueue). To run tests in a Linux environment matching production:
+
+```sh
+./bin/test-linux.sh
+```
+
+This builds a Docker container with Debian Bookworm (matching production), then runs the full test suite.
+
 ## Supplying the attendance id
 
 Each learner in a coaching session is given an "attendance id", a random number which they need to pass on

--- a/bin/test-linux.sh
+++ b/bin/test-linux.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Script to run tests in a Linux container for debugging platform-specific issues
+
+IMAGE_NAME="learnersync-test"
+
+echo "Building Docker image..."
+docker build -f Dockerfile.test -t $IMAGE_NAME .
+
+echo ""
+echo "Running all tests in Linux container..."
+docker run --rm -v "$(pwd):/app" $IMAGE_NAME
+
+echo ""
+echo "Tests completed!"


### PR DESCRIPTION
We had a situation where linux/macos behaved differently.  To help debug and test locally on a mac with a similar environment to prod / ci we create a test dockerfile and script that builds that and runs the tests.

Example of catching this test which was failing on this branch: https://github.com/skiller-whale/learnersync/pull/34
<img width="691" height="122" alt="image" src="https://github.com/user-attachments/assets/15380f7d-7944-4ee8-a662-76bf86ceaa40" />

